### PR TITLE
Add responsive sidebar menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,10 @@
     <button class="theme-toggle" onclick="toggleTheme()">
         <i data-lucide="sun" id="theme-icon"></i>
     </button>
+
+    <button class="menu-toggle" onclick="toggleMenu()">
+        <i data-lucide="menu"></i>
+    </button>
     
     <div class="app-container">
         <nav class="sidebar">

--- a/script.js
+++ b/script.js
@@ -455,6 +455,7 @@ function reinitializeIcons() {
 // Call after page switches
 document.querySelectorAll('.nav-link').forEach(link => {
     link.addEventListener('click', reinitializeIcons);
+    link.addEventListener('click', closeMenuOnMobile);
 });
 
 // Theme toggle functionality
@@ -572,4 +573,15 @@ function initializeSettings() {
     // Initialize Strava connection status
     toggleStravaConnection();
     toggleStravaConnection(); // Reset to actual state
+}
+
+function toggleMenu() {
+    const sidebar = document.querySelector('.sidebar');
+    sidebar.classList.toggle('open');
+}
+
+function closeMenuOnMobile() {
+    if (window.innerWidth <= 768) {
+        document.querySelector('.sidebar').classList.remove('open');
+    }
 }

--- a/styles.css
+++ b/styles.css
@@ -51,6 +51,7 @@ body {
     position: fixed;
     height: 100vh;
     overflow-y: auto;
+    transition: transform 0.3s ease;
 }
 
 .nav-brand {
@@ -774,6 +775,34 @@ body {
     color: var(--accent-primary);
 }
 
+/* Mobile menu toggle */
+.menu-toggle {
+    position: fixed;
+    top: 2rem;
+    left: 2rem;
+    width: 48px;
+    height: 48px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    z-index: 1000;
+}
+
+.menu-toggle:hover {
+    transform: scale(1.1);
+}
+
+.menu-toggle i {
+    width: 24px;
+    height: 24px;
+    color: var(--accent-primary);
+}
+
 /* Update chart colors for light theme */
 [data-theme="light"] .chart-container canvas {
     filter: invert(0.1);
@@ -981,9 +1010,21 @@ input:checked + .slider:before {
 
 @media (max-width: 768px) {
     .sidebar {
-        width: 100%;
-        position: static;
-        height: auto;
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 260px;
+        height: 100vh;
+        transform: translateX(-100%);
+        z-index: 999;
+    }
+
+    .sidebar.open {
+        transform: translateX(0);
+    }
+
+    .menu-toggle {
+        display: flex;
     }
     
     .main-content {


### PR DESCRIPTION
## Summary
- add mobile menu button
- make sidebar responsive on small screens
- close mobile menu when selecting a page

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68862f2bc00483298018d45d9df3c3e7